### PR TITLE
Add reload method to Document

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ mydb.get('/woot/woot');
   Loads a document from the given URL. If `fn` is supplied, it's passed
   to `ready`.
 
+### Document#reload([fn])
+
+  Reloads from the URL that was previously given to `Document#load`. Useful if a given endpoint can return different documents depending on the circumstances. Example: a `/me` route that returns the currently signed-in user.
+
 ### Document#ready(fn)
 
   Calls the supplied `fn` when the resource is loaded. If the resource

--- a/document.js
+++ b/document.js
@@ -390,6 +390,20 @@ Document.prototype.load = function(url, fn){
 };
 
 /**
+ * Reloads from the previously used URL
+ *
+ * @return {Document} for chaining
+ * @api public
+ */
+
+Document.prototype.reload = function(fn){
+  if (!this.$_url) {
+    throw new Error('Cannot reload: You must call .load() first and specify a URL.');
+  }
+  return this.load(this.$_url, fn);
+}
+
+/**
  * Subscribe to a given `sid`.
  *
  * @param {Response} response


### PR DESCRIPTION
This PR adds a `.reload()` method to `Document`, that reloads the document from the last used URL. Useful if the endpoint can return different documents depending on the circumstances like `/me`.